### PR TITLE
unescape strings with jsesc

### DIFF
--- a/src/deobfuscator/deobfuscator.ts
+++ b/src/deobfuscator/deobfuscator.ts
@@ -103,7 +103,7 @@ export class Deobfuscator {
             }
         }
 
-        return generate(this.ast).code;
+        return generate(this.ast, { jsescOption: { minimal: true }}).code;
     }
 
     /**

--- a/src/deobfuscator/transformations/strings/stringRevealer.ts
+++ b/src/deobfuscator/transformations/strings/stringRevealer.ts
@@ -226,8 +226,7 @@ export class StringRevealer extends Transformation {
                         self.setChanged();
                     }
                 } else if (self.isEscapedStringLiteral(path.node)) {
-                    const extra = path.node.extra as Record<string, string>;
-                    extra.raw = `'${extra.rawValue.replace(/'/g, "\\'")}'`;
+                    path.node.extra = undefined;
                     self.setChanged();
                 }
             }


### PR DESCRIPTION
fixes #13 
example output:
```diff
- console.log("\x41", "Hello\nWorld!", 'a\'b"c', "a\"b'c");
+ console.log("A", "Hello\nWorld!", "a'b\"c", "a\"b'c");
```