### PR TITLE
Directly depend on @babel/parser instead of relying on an external script in browser.

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -15,8 +15,6 @@ program
     .option('-o, --output [output_path]', 'output file path', 'deobfuscated.js')
     .option('-s, --silent', 'emit nothing to stdout')
     .action((input, options) => {
-        (globalThis as any).parser = { parse, parseExpression };
-
         const source = fs.readFileSync(input).toString();
         const ast = parse(source, { sourceType: 'unambiguous' });
 

--- a/src/deobfuscator/helpers/misc.ts
+++ b/src/deobfuscator/helpers/misc.ts
@@ -1,5 +1,6 @@
 import generate from '@babel/generator';
 import * as t from '@babel/types';
+import {parseExpression} from '@babel/parser';
 
 /**
  * Copies an expression.
@@ -7,8 +8,6 @@ import * as t from '@babel/types';
  * @returns The copy.
  */
 export const copyExpression = (expression: t.Expression): t.Expression => {
-    const parseExpression: (code: string) => t.Expression = (globalThis as any).parser
-        .parseExpression;
     return parseExpression(generate(expression).code);
 };
 

--- a/src/webpackEntry.ts
+++ b/src/webpackEntry.ts
@@ -1,3 +1,4 @@
+import { parse } from '@babel/parser';
 import { Deobfuscator } from './deobfuscator/deobfuscator';
 import { Config } from './deobfuscator/transformations/config';
 
@@ -8,8 +9,7 @@ import { Config } from './deobfuscator/transformations/config';
  * @returns The deobfuscated code.
  */
 export function deobfuscate(source: string, config: Config): string {
-    // parse function is added by external script in browser
-    const ast = (globalThis as any).parser.parse(source, { sourceType: 'unambiguous' });
+    const ast = parse(source, { sourceType: 'unambiguous' });
 
     const deobfuscator = new Deobfuscator(ast, config);
     const output = deobfuscator.execute();


### PR DESCRIPTION
Is it okay to just directly depend on @babel/parser like in this PR? I tried webpack and it still works.

Thanks!