### PR TITLE
Fixed simplification of big int literal expressions.

### DIFF
--- a/src/deobfuscator/transformations/expressions/expressionSimplifier.ts
+++ b/src/deobfuscator/transformations/expressions/expressionSimplifier.ts
@@ -223,8 +223,9 @@ export class ExpressionSimplifier extends Transformation {
             case 'StringLiteral':
             case 'BooleanLiteral':
             case 'DecimalLiteral':
-            case 'BigIntLiteral':
                 return expression.value;
+            case 'BigIntLiteral':
+                return BigInt(expression.value);
             case 'UnaryExpression':
                 return -this.getResolvableExpressionValue(
                     expression.argument as Exclude<t.Literal, t.RegExpLiteral | t.TemplateLiteral>


### PR DESCRIPTION
These were getting treated as a regular number and being clamped in certain situations.

For example the expression:
`(0x1n << 0x30n) - 0x1n` was being simplified to `65535`

I tried to debug why and here's what happened:
```
Simplified binary expression: BigIntLiteral BigIntLiteral 0x1 << 0x30 = 65536
Simplified binary expression: NumericLiteral BigIntLiteral 65536 - 0x1 = 65535
```

With this fix, it simplifies it to `281474976710655n` (big int), as expected.